### PR TITLE
fix #2: slightly fresher bounds for GHC 9.0.2

### DIFF
--- a/libjwt-typed.cabal
+++ b/libjwt-typed.cabal
@@ -51,19 +51,20 @@ tested-with:         GHC == 8.8.3
                      GHC == 8.10.1
                      GHC == 8.10.2
                      GHC == 8.10.3
+                     GHC == 9.0.2
 
 source-repository head
   type:                git
   location:            https://github.com/marcin-rzeznicki/libjwt-typed.git
 
 common common-options
-  build-depends:       base >= 4.13.0.0 && < 4.15,
+  build-depends:       base >= 4.13.0.0 && < 4.16,
                        bytestring ^>= 0.10.10.0,
                        exceptions ==0.10.4,
                        either ^>= 5.0.1.1,
                        transformers ^>= 0.5.6.2,
                        uuid >= 1.3,
-                       text >= 1.2.3.2 && < 1.2.5,
+                       text >= 1.2.3.2 && <= 1.2.5.0,
                        time >=1.9 && < 1.10,
                        monad-time ==0.3.*,
                        data-default >= 0.2 && < 1.0,


### PR DESCRIPTION
Resolve the issue of this package not building
for GHC 9.0.2 due to `base` and `text` bounds
being too restrictive by simply slightly
increasing the freshest/upper bound for both.

Tests have not been manually ran for this commit.
Assuming all works well because I'm using
libjwt-typed with nixpkgs in my project that now
uses GHC 9.0.2.