### PR TITLE
Relax monad-time bounds, and add a workaround for `now`

### DIFF
--- a/libjwt-typed.cabal
+++ b/libjwt-typed.cabal
@@ -60,14 +60,14 @@ common common-options
   build-depends:       base >= 4.13.0.0 && < 4.20,
                        bytestring >= 0.10.10.0,
                        exceptions >=0.10.4,
-                       either ^>= 5.0.1.1,
-                       transformers ^>= 0.5.6.2,
+                       either >= 5.0.1.1,
+                       transformers >= 0.5.6.2,
                        uuid >= 1.3,
                        text >= 1.2.3.2 && <3,
-                       time >=1.9 && < 1.10,
-                       monad-time >=0.3 && <0.5,
-                       data-default >= 0.2 && < 1.0,
-                       extra ^>= 1.7,
+                       time >=1.9,
+                       monad-time >=0.3 ,
+                       data-default >= 0.2,
+                       extra >= 1.7,
   
   ghc-options:         -Wall
                        -Wcompat
@@ -90,10 +90,10 @@ common common-options
 library
   import:              common-options
   hs-source-dirs:      src
-  build-depends:       unordered-containers ^>= 0.2.10.0,
-                       utf8-string ^>= 1.0.1.1,
+  build-depends:       unordered-containers >= 0.2.10.0,
+                       utf8-string >= 1.0.1.1,
                        proxied ==0.3.*,
-                       casing ^>= 0.1.4.1,
+                       casing >= 0.1.4.1,
                        case-insensitive >= 1.2.0.0
   exposed-modules:     Web.Libjwt
                        Libjwt.Jwt

--- a/libjwt-typed.cabal
+++ b/libjwt-typed.cabal
@@ -57,13 +57,13 @@ source-repository head
   location:            https://github.com/marcin-rzeznicki/libjwt-typed.git
 
 common common-options
-  build-depends:       base >= 4.13.0.0 && < 4.15,
-                       bytestring ^>= 0.10.10.0,
-                       exceptions ==0.10.4,
+  build-depends:       base >= 4.13.0.0 && < 4.20,
+                       bytestring >= 0.10.10.0,
+                       exceptions >=0.10.4,
                        either ^>= 5.0.1.1,
                        transformers ^>= 0.5.6.2,
                        uuid >= 1.3,
-                       text >= 1.2.3.2 && < 1.2.5,
+                       text >= 1.2.3.2 && <3,
                        time >=1.9 && < 1.10,
                        monad-time >=0.3 && <0.5,
                        data-default >= 0.2 && < 1.0,

--- a/libjwt-typed.cabal
+++ b/libjwt-typed.cabal
@@ -65,7 +65,7 @@ common common-options
                        uuid >= 1.3,
                        text >= 1.2.3.2 && < 1.2.5,
                        time >=1.9 && < 1.10,
-                       monad-time ==0.3.*,
+                       monad-time >=0.3 && <0.5,
                        data-default >= 0.2 && < 1.0,
                        extra ^>= 1.7,
   

--- a/src/Libjwt/Payload.hs
+++ b/src/Libjwt/Payload.hs
@@ -52,6 +52,7 @@ import           Data.Function                  ( (&) )
 import           Data.Monoid
 
 import           Data.Time.Clock
+import           Data.Time.Clock.POSIX
 
 import           Data.UUID                      ( UUID )
 
@@ -195,7 +196,13 @@ step = JwtBuilder . Ap . pure . Endo
 stepWithCurrentTime
   :: (NumericDate -> Payload any1 any2 -> Payload any1 any2)
   -> JwtBuilder any1 any2
-stepWithCurrentTime f = JwtBuilder . Ap $ fmap (Endo . f) now
+stepWithCurrentTime f = JwtBuilder . Ap $ fmap (Endo . f) askEpoch
+  where
+    askEpoch = do
+      utcTime <- ask
+      let posixTime = utcTimeToPOSIXSeconds utcTime
+      let secondsSinceEpoch = nominalDiffTimeToSeconds posixTime
+      pure $ NumericDate $ round secondsSinceEpoch
 
 -- | Set /iss/ claim
 withIssuer :: String -> JwtBuilder any1 any2


### PR DESCRIPTION
`monad-time` 0.4.0.0 removed an instance `Monad m => MonadTime (ReaderT UTCTime m)`

Which was required for `now` in `Libjwt.Payload`.

Luckily, it seems easy enough to create a `NumericDate` in a `MonadReader UTCTime m`